### PR TITLE
Add lecture player resolution options and UI

### DIFF
--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -263,25 +263,8 @@ const VideoPlayer = ({
 
   // Get available quality options based on video type
   const getAvailableQualityOptions = () => {
-    const options = [{ value: 'auto', label: 'Auto' }];
-    
-    if (videoType === 'hls' && availableQualities.length > 0) {
-      // Use actual available qualities from HLS stream
-      availableQualities.forEach(quality => {
-        const label = `${quality.height}p${quality.height >= 720 ? ' HD' : ''}`;
-        options.push({ value: quality.level.toString(), label });
-      });
-    } else {
-      // Use standard quality options, ensuring 720p and 480p are available
-      const standardQualities = ['1080', '720', '480', '360', '240'];
-      standardQualities.forEach(quality => {
-        const height = parseInt(quality);
-        const label = `${quality}p${height >= 720 ? ' HD' : ''}`;
-        options.push({ value: quality, label });
-      });
-    }
-    
-    return options;
+    // Always return all standard quality options to ensure 720p and 480p are available
+    return QUALITY_OPTIONS;
   };
 
   return (


### PR DESCRIPTION
Simplify video quality option selection to ensure all standard qualities are always visible.

The previous `getAvailableQualityOptions` function had complex logic that inadvertently filtered out 720p and 480p options, especially for HLS streams, leading to only "Auto" and "1080p" being displayed. This change ensures all predefined `QUALITY_OPTIONS` are consistently available to the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c22b1ee-d300-4612-ba0b-1a3f1aa82a48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c22b1ee-d300-4612-ba0b-1a3f1aa82a48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

